### PR TITLE
apply sample of systemd service

### DIFF
--- a/rizond.service
+++ b/rizond.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=RIZON daemon service
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu
+ExecStart=/home/ubuntu/go/bin/rizond start
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If you want to launch `rizond` via systemd service, you need to modify
`rizond.service` for your environment and enable it.