### PR TITLE
fix: change cointype to 118

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,46 @@
 BINDIR ?= $(GOPATH)/bin
 VERSION := $(shell git describe --tags)
 COMMIT := $(shell git log -1 --format='%H')
-BUILDTAGS := $(shell uname)
 TM_VERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')
+LEDGER_ENABLED ?= true
+
+# process build tags
+
+build_tags = netgo
+ifeq ($(LEDGER_ENABLED),true)
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S),OpenBSD)
+    $(warning OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988))
+  else
+    GCC = $(shell command -v gcc 2> /dev/null)
+    ifeq ($(GCC),)
+      $(error gcc not installed for ledger support, please install or set LEDGER_ENABLED=false)
+    else
+      build_tags += ledger
+    endif
+  endif
+endif
+
+build_tags += $(BUILD_TAGS)
+build_tags := $(strip $(build_tags))
+
+whitespace :=
+whitespace += $(whitespace)
+comma := ,
+build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
+
+# process linker flags
 
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=rizon \
 	  -X github.com/cosmos/cosmos-sdk/version.AppName=rizond \
 	  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-	  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(BUILDTAGS)" \
+	  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
 	  -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TM_VERSION)
+ldflags += $(LDFLAGS)
+ldflags := $(strip $(ldflags))
+
+BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 
 .PHONY: install protocgen update-swagger-docs
 
@@ -25,7 +56,7 @@ update-swagger-docs: statik
     fi
 
 install: go.sum
-	go install -mod=readonly -ldflags '$(ldflags)' ./cmd/rizond
+	go install -mod=readonly $(BUILD_FLAGS) ./cmd/rizond
 
 go.sum: go.mod
 	@go mod verify

--- a/types/cointype.go
+++ b/types/cointype.go
@@ -2,11 +2,12 @@ package types
 
 const (
 	// CoinType is the ATOLO coin type as defined in SLIP44 (https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
-	CoinType = 1217
+	// Currently we follow atom cointype for supporting third party
+	CoinType = 118
 
 	// FullFundraiserPath is the parts of the BIP44 HD path that are fixed by
 	// what we used during the ATOLO fundraiser.
-	FullFundraiserPath = "m/44'/1217'/0'/0/0"
+	FullFundraiserPath = "m/44'/118'/0'/0/0"
 
 	// DefaultDenom is base cointype of ATOLO coin
 	DefaultDenom = "uatolo"


### PR DESCRIPTION
Before third party prepare to support RIZON, we follow atom's cointype to support third party tools like ledger nano, web wallet, etc for enhancing usability.