### PR TITLE
fix: add missing capability beginBlocker

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -368,7 +368,7 @@ func NewRizonApp(
 	// CanWithdrawInvariant invariant.
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	app.mm.SetOrderBeginBlockers(
-		upgradetypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
+		upgradetypes.ModuleName, capabilitytypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName,
 	)
 	app.mm.SetOrderEndBlockers(crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName, treasurytypes.ModuleName)


### PR DESCRIPTION
Fix the IBC channel creation issue on Rizon-Network

tested on local testnet with:
 - titan-1 (rizond v0.2.8 + patch)
 - cosmoshub-4 (gaiad v6.0.0)
 - osmosis-1 (osmosis v6.2.0)

- [x] IBC channel creation between titan-1 and cosmoshub-4
- [x] IBC channel creation between titan-1 and osmosis-1
- [x] IBC transfer between titan-1 and cosmoshub-4
- [x] IBC transfer between titan-1 and osmosis-1

Signed-off-by: Galadrin <dapie@cros-nest.com>